### PR TITLE
Forcibly disables decomposition

### DIFF
--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -57,6 +57,7 @@
 		examine_type = DECOMP_EXAM_GROSS
 
 	handle_movement()
+	QDEL_IN(src, 1) // BEGONE YE
 
 
 /datum/component/decomposition/UnregisterFromParent()


### PR DESCRIPTION
This is done by just having the component schedule itself for immediate deletion. Is it the best way to do this? No. Does it work? Yes!