### PR TITLE
Trait-limited content + The spawn points

### DIFF
--- a/_maps/map_files/ToolboxOfTerror/toolbox_of_terror.dmm
+++ b/_maps/map_files/ToolboxOfTerror/toolbox_of_terror.dmm
@@ -104,9 +104,6 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood/large,
 /area/awaymission/cabin/snowforest)
-"aZ" = (
-/turf/open/floor/plastic,
-/area/vip_only)
 "bh" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -1229,9 +1226,6 @@
 	dir = 1
 	},
 /area/awaymission/cabin/snowforest)
-"nj" = (
-/turf/open/floor/carpet/red,
-/area/vip_only)
 "nl" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/chem_dispenser/drinks{
@@ -1715,6 +1709,9 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
 /area/awaymission/cabin/snowforest)
+"rn" = (
+/turf/closed/indestructible/wood,
+/area/vip_only)
 "rs" = (
 /obj/structure/closet/crate/grave/filled/lead_researcher,
 /turf/open/floor/grass,
@@ -1981,6 +1978,9 @@
 	icon_state = "wood_large-broken2"
 	},
 /area/awaymission/cabin/snowforest)
+"tQ" = (
+/turf/open/floor/plastic,
+/area/vip_only)
 "tS" = (
 /obj/structure/window/bronze/fulltile,
 /turf/open/floor/wood,
@@ -2417,6 +2417,10 @@
 	},
 /turf/open/floor/gravel,
 /area/awaymission/cabin/snowforest)
+"ys" = (
+/obj/machinery/door/airlock/bronze/trait_limited,
+/turf/open/floor/carpet/red,
+/area/vip_only)
 "yy" = (
 /obj/structure/chair/pew/right,
 /turf/open/floor/grass,
@@ -3716,6 +3720,9 @@
 	},
 /turf/open/floor/grass,
 /area/awaymission/cabin/snowforest)
+"Mg" = (
+/turf/open/floor/carpet/red,
+/area/vip_only)
 "Mh" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/botanic_leather{
@@ -4566,9 +4573,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/grass,
 /area/awaymission/cabin/snowforest)
-"TY" = (
-/turf/closed/indestructible/wood,
-/area/vip_only)
 "TZ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/dirt,
@@ -29154,11 +29158,11 @@ LW
 LW
 LW
 Fr
-nj
+Mg
 xU
 wX
 xW
-aZ
+tQ
 ff
 By
 By
@@ -29283,12 +29287,12 @@ Fr
 LW
 LW
 LW
-LW
-nj
-nj
+ys
+Mg
+Mg
 xu
-nj
-aZ
+Mg
+tQ
 ff
 By
 By
@@ -29415,10 +29419,10 @@ LW
 LW
 Fr
 wW
-nj
-nj
-nj
-aZ
+Mg
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -29546,9 +29550,9 @@ LW
 Fr
 wX
 xW
-nj
+Mg
 xU
-aZ
+tQ
 ff
 By
 By
@@ -29674,11 +29678,11 @@ LW
 LW
 LW
 Fr
-TY
+rn
 yb
-nj
-nj
-aZ
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -29806,9 +29810,9 @@ LW
 fH
 xe
 yH
-nj
-nj
-aZ
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -29936,9 +29940,9 @@ LW
 fH
 xe
 yH
-nj
-nj
-aZ
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -30066,7 +30070,7 @@ wM
 fH
 xe
 yH
-nj
+Mg
 xU
 FC
 ff
@@ -30196,9 +30200,9 @@ LW
 fH
 xe
 yH
-nj
-nj
-aZ
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -30326,9 +30330,9 @@ LW
 fH
 xe
 yH
-nj
-nj
-aZ
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -30454,11 +30458,11 @@ LW
 LW
 LW
 Fr
-TY
+rn
 yI
-nj
-nj
-aZ
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -30586,9 +30590,9 @@ LW
 Fr
 wX
 xW
-nj
+Mg
 xU
-aZ
+tQ
 ff
 By
 By
@@ -30715,10 +30719,10 @@ LW
 LW
 Fr
 xu
-nj
-nj
-nj
-aZ
+Mg
+Mg
+Mg
+tQ
 ff
 By
 By
@@ -30843,12 +30847,12 @@ Fr
 LW
 LW
 LW
-LW
-nj
-nj
+ys
+Mg
+Mg
 wW
-nj
-aZ
+Mg
+tQ
 ff
 By
 By
@@ -30974,11 +30978,11 @@ LW
 LW
 LW
 Fr
-nj
+Mg
 xU
 wX
 xW
-aZ
+tQ
 ff
 Bz
 By

--- a/_maps/map_files/ToolboxOfTerror/toolbox_of_terror.dmm
+++ b/_maps/map_files/ToolboxOfTerror/toolbox_of_terror.dmm
@@ -104,6 +104,9 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood/large,
 /area/awaymission/cabin/snowforest)
+"aZ" = (
+/turf/open/floor/plastic,
+/area/vip_only)
 "bh" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -1226,6 +1229,9 @@
 	dir = 1
 	},
 /area/awaymission/cabin/snowforest)
+"nj" = (
+/turf/open/floor/carpet/red,
+/area/vip_only)
 "nl" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/chem_dispenser/drinks{
@@ -2274,16 +2280,20 @@
 /obj/structure/table/bronze,
 /turf/open/floor/carpet/red,
 /area/awaymission/cabin/snowforest)
+"wP" = (
+/obj/effect/landmark/latejoin,
+/turf/open/floor/gravel,
+/area/awaymission/cabin/snowforest)
 "wW" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "wX" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "xa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -2297,7 +2307,7 @@
 "xe" = (
 /obj/structure/table/bronze,
 /turf/open/floor/wood,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "xf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2321,7 +2331,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "xz" = (
 /turf/open/floor/carpet/royalblue,
 /area/awaymission/cabin/snowforest)
@@ -2359,19 +2369,19 @@
 "xU" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "xW" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "yb" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "yf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
@@ -2426,13 +2436,13 @@
 "yH" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "yI" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
 /turf/open/floor/carpet/red,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "yL" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron/stairs/right{
@@ -3157,7 +3167,7 @@
 "FC" = (
 /obj/machinery/light/dim,
 /turf/open/floor/plastic,
-/area/awaymission/cabin/snowforest)
+/area/vip_only)
 "FG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -4169,7 +4179,7 @@
 /turf/open/floor/wood,
 /area/awaymission/cabin/snowforest)
 "PW" = (
-/obj/effect/landmark/start,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/gravel,
 /area/awaymission/cabin/snowforest)
 "PY" = (
@@ -4556,6 +4566,9 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/grass,
 /area/awaymission/cabin/snowforest)
+"TY" = (
+/turf/closed/indestructible/wood,
+/area/vip_only)
 "TZ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/dirt,
@@ -4854,6 +4867,10 @@
 	},
 /turf/open/floor/wood/large,
 /area/tdome/tdome1)
+"Xe" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/gravel,
+/area/awaymission/cabin/snowforest)
 "Xf" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/mirror/directional/south,
@@ -29137,11 +29154,11 @@ LW
 LW
 LW
 Fr
-LW
+nj
 xU
 wX
 xW
-kD
+aZ
 ff
 By
 By
@@ -29199,17 +29216,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
 TA
 Ps
 "}
@@ -29267,11 +29284,11 @@ LW
 LW
 LW
 LW
-LW
-LW
+nj
+nj
 xu
-LW
-kD
+nj
+aZ
 ff
 By
 By
@@ -29329,17 +29346,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
 TA
 Ps
 "}
@@ -29398,10 +29415,10 @@ LW
 LW
 Fr
 wW
-LW
-LW
-LW
-kD
+nj
+nj
+nj
+aZ
 ff
 By
 By
@@ -29459,17 +29476,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -29529,9 +29546,9 @@ LW
 Fr
 wX
 xW
-LW
+nj
 xU
-kD
+aZ
 ff
 By
 By
@@ -29589,17 +29606,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -29657,11 +29674,11 @@ LW
 LW
 LW
 Fr
-Fr
+TY
 yb
-LW
-LW
-kD
+nj
+nj
+aZ
 ff
 By
 By
@@ -29719,17 +29736,17 @@ nQ
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -29789,9 +29806,9 @@ LW
 fH
 xe
 yH
-LW
-LW
-kD
+nj
+nj
+aZ
 ff
 By
 By
@@ -29849,17 +29866,17 @@ Ht
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -29919,9 +29936,9 @@ LW
 fH
 xe
 yH
-LW
-LW
-kD
+nj
+nj
+aZ
 ff
 By
 By
@@ -29979,17 +29996,17 @@ Vi
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -30049,7 +30066,7 @@ wM
 fH
 xe
 yH
-LW
+nj
 xU
 FC
 ff
@@ -30109,18 +30126,18 @@ mM
 Xx
 TA
 TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-PW
 Ps
 "}
 (65,1,2) = {"
@@ -30179,9 +30196,9 @@ LW
 fH
 xe
 yH
-LW
-LW
-kD
+nj
+nj
+aZ
 ff
 By
 By
@@ -30239,17 +30256,17 @@ Wc
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -30309,9 +30326,9 @@ LW
 fH
 xe
 yH
-LW
-LW
-kD
+nj
+nj
+aZ
 ff
 By
 By
@@ -30369,17 +30386,17 @@ wg
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -30437,11 +30454,11 @@ LW
 LW
 LW
 Fr
-Fr
+TY
 yI
-LW
-LW
-kD
+nj
+nj
+aZ
 ff
 By
 By
@@ -30499,17 +30516,17 @@ no
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -30569,9 +30586,9 @@ LW
 Fr
 wX
 xW
-LW
+nj
 xU
-kD
+aZ
 ff
 By
 By
@@ -30629,17 +30646,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -30698,10 +30715,10 @@ LW
 LW
 Fr
 xu
-LW
-LW
-LW
-kD
+nj
+nj
+nj
+aZ
 ff
 By
 By
@@ -30759,17 +30776,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+Xe
+wP
+wP
+wP
 TA
 Ps
 "}
@@ -30827,11 +30844,11 @@ LW
 LW
 LW
 LW
-LW
-LW
+nj
+nj
 wW
-LW
-kD
+nj
+aZ
 ff
 By
 By
@@ -30889,17 +30906,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
 TA
 Ps
 "}
@@ -30957,11 +30974,11 @@ LW
 LW
 LW
 Fr
-LW
+nj
 xU
 wX
 xW
-kD
+aZ
 ff
 Bz
 By
@@ -31019,17 +31036,17 @@ cq
 my
 TA
 TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
+PW
 TA
 Ps
 "}

--- a/modular_event/trait_limited_content/airlocks.dm
+++ b/modular_event/trait_limited_content/airlocks.dm
@@ -1,0 +1,15 @@
+/obj/machinery/door/airlock/bronze/trait_limited
+
+/obj/machinery/door/airlock/bronze/trait_limited/allowed(mob/user)
+	. = ..()
+	if (!.)
+		return .
+
+	var/area/area = get_area(src)
+	if (isnull(area.trait_required))
+		return .
+
+	return HAS_TRAIT(user, area.trait_required)
+
+/obj/machinery/door/airlock/bronze/trait_limited/CanAllowThrough(atom/movable/mover, border_dir)
+	return ..() && ismob(mover) && allowed(mover)

--- a/modular_event/trait_limited_content/areas.dm
+++ b/modular_event/trait_limited_content/areas.dm
@@ -1,0 +1,76 @@
+SUBSYSTEM_DEF(trait_limited_areas)
+	name = "Event - Trait Limited Areas"
+	wait = 2 SECONDS
+
+	var/list/current_run = list()
+
+/datum/controller/subsystem/trait_limited_areas/fire(resumed)
+	if (!resumed)
+		current_run = GLOB.player_list.Copy()
+
+	while (length(current_run))
+		var/mob/mob = pop(current_run)
+
+		if (QDELETED(mob) || isnull(mob.key) || !isliving(mob))
+			continue
+
+		var/area/area = get_area(mob)
+		if (!isnull(area.trait_required) && !HAS_TRAIT(mob, area.trait_required))
+			var/turf/turf = get_turf(mob)
+			message_admins("[key_name_admin(mob)] was in [area] without the [area.trait_required] trait! <a href='?src=[REF(src)];area=[REF(area)];mob=[REF(mob)];turf=[REF(turf)]'>GIVE TRAIT (AND TELEPORT BACK)</a>")
+			mob.forceMove(mob.mind?.assigned_role?.get_latejoin_spawn_point() || pick(SSjob.latejoin_trackers) || SSjob.get_last_resort_spawn_points())
+
+		if (MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/trait_limited_areas/Topic(href, list/href_list)
+	. = ..()
+	if (.)
+		return
+
+	if (isnull(usr.client?.holder))
+		message_admins("[key_name_admin(usr)] tried to use a Topic on the limited areas SS without permission.")
+		log_admin_private("[key_name(usr)] tried to use a Topic on the limited areas SS without permission.")
+
+		return
+
+	var/area_ref = href_list["area"]
+	if (isnull(area_ref))
+		return
+
+	var/area/area = locate(area_ref)
+	var/mob/mob = locate(href_list["mob"])
+	var/turf/turf = locate(href_list["turf"])
+
+	if (!istype(area))
+		to_chat(usr, span_warning("The area ref is invalid!"))
+		return
+
+	if (!istype(mob))
+		to_chat(usr, span_warning("The mob ref is invalid! Maybe they respawned?"))
+		return
+
+	if (isnull(area.trait_required))
+		to_chat(usr, span_warning("The area you are limiting to doesn't have a trait!"))
+		return
+
+	ADD_TRAIT(mob, area.trait_required, "[type]")
+
+	message_admins("[key_name(usr)] has given [key_name_admin(mob)] the trait required to enter [area].")
+	log_admin("[key_name(usr)] has given [key_name(mob)] the trait required to enter [area].")
+
+	to_chat(mob, span_boldnotice("You have been given access to enter [area]!"))
+
+	if (!istype(turf))
+		to_chat(usr, span_warning("The mob was given the trait, but somehow, the turf reference is invalid!"))
+		return
+
+	mob.forceMove(turf)
+
+/area
+	var/trait_required = null
+
+/area/vip_only
+	name = "VIP Room"
+	icon_state = "yellow"
+	trait_required = TRAIT_VIP

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3959,5 +3959,6 @@
 #include "modular_event\tournament\teams.dm"
 #include "modular_event\tournament\toolbox.dm"
 #include "modular_event\tournament\tournament_spawn.dm"
+#include "modular_event\trait_limited_content\airlocks.dm"
 #include "modular_event\trait_limited_content\areas.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3959,4 +3959,5 @@
 #include "modular_event\tournament\teams.dm"
 #include "modular_event\tournament\toolbox.dm"
 #include "modular_event\tournament\tournament_spawn.dm"
+#include "modular_event\trait_limited_content\areas.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Describe The Pull Request. Please be sure changes are documented for posterity as they may want to refer back to reuse and port all or part of it for future events, also good PR descriptions will make merge delays far less likely. -->
<!-- If this is a Sprite or Map contribution please include screenshots if the diff bots fail for whatever reason. -->
Adds the spawn points, both roundstart and latejoin.

Lets areas limit themselves by a trait required. Adds the VIP area to accommodate this.

Adds airlocks that limit access to those with the trait. Even if open, will block items/mobs from entering through without the trait.

When a mob is blocked from being inside a room, admins will be given a button to add the trait and teleport back.