### PR TITLE
Inert outfit code and team IDs

### DIFF
--- a/modular_event/auto_equip/auto_equip.dm
+++ b/modular_event/auto_equip/auto_equip.dm
@@ -41,25 +41,65 @@ SUBSYSTEM_DEF(auto_equip)
 
 	var/ckey = ckey(mind?.key)
 	var/team_outfit
+	var/team_camo
 
 	for (var/team_name in GLOB.tournament_teams)
 		var/datum/tournament_team/tournament_team = GLOB.tournament_teams[team_name]
 
 		if (ckey in tournament_team.roster)
 			team_outfit = tournament_team.outfit
+			team_camo = tournament_team.camo_placeholder
 			break
 
 	if (team_outfit)
 		// Equip everything else *after* team stuff, so they have their backpacks still.
-		equipOutfit(team_outfit, visual_only)
+		equipInertOutfit(team_outfit, team_camo)
 
 	if (ckey in SSauto_equip.vips)
 		equipOutfit(/datum/outfit/job/vip, visual_only)
 	else
 		equipOutfit(equipping.outfit, visual_only)
 
+/mob/living/carbon/human/proc/equipInertOutfit(datum/outfit/model_outfit, datum/outfit/camo_outfit, changeable = TRUE)
+	camo_outfit.equip(src)
+
+	// mostly copy pasta from chameleon_outfit/proc/select_outfit but a lot less restrictive
+	var/list/outfit_parts = model_outfit.get_chameleon_disguise_info()
+	for(var/V in chameleon_item_actions)
+		var/datum/action/item_action/chameleon/change/change_action = V
+		for(var/outfit_part in outfit_parts)
+			if(ispath(outfit_part, change_action.chameleon_type))
+				change_action.update_look(src, outfit_part)
+				break
+		var/atom/target = change_action.target
+		// make the gear fully combat inert
+		target.armor = new
+
+	//hardsuit helmets/suit hoods
+	if(model_outfit.toggle_helmet && (ispath(model_outfit.suit, /obj/item/clothing/suit/space/hardsuit) || ispath(model_outfit.suit, /obj/item/clothing/suit/hooded)))
+		//make sure they are actually wearing the suit, not just holding it, and that they have a chameleon hat
+		if(istype(wear_suit, /obj/item/clothing/suit/chameleon) && istype(head, /obj/item/clothing/head/chameleon))
+			var/helmet_type
+			if(ispath(model_outfit.suit, /obj/item/clothing/suit/space/hardsuit))
+				var/obj/item/clothing/suit/space/hardsuit/hardsuit = model_outfit.suit
+				helmet_type = initial(hardsuit.helmettype)
+			else
+				var/obj/item/clothing/suit/hooded/hooded = model_outfit.suit
+				helmet_type = initial(hooded.hoodtype)
+
+			if(helmet_type)
+				var/obj/item/clothing/head/chameleon/hat = head
+				hat.chameleon_action.update_look(src, helmet_type)
+
+	if(!changeable)
+		for(var/action in chameleon_item_actions)
+			qdel(action) // we can't just QDEL_LIST instead because the Cut() will fail
+
 /datum/outfit/job/vip
 	name = "Donator"
+	id = /obj/item/card/id/advanced/gold
+	id_trim = /datum/id_trim/centcom/vip
+
 	box = /obj/item/storage/box/tournament/vip
 	backpack_contents = list(/obj/item/storage/box/syndie_kit/chameleon = 1)
 
@@ -67,7 +107,6 @@ SUBSYSTEM_DEF(auto_equip)
 	head = /obj/item/clothing/head/bowler
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/suit/black_really
-	glasses = /obj/item/clothing/glasses/hud/health
 	gloves = /obj/item/clothing/gloves/color/white
 
 // Tournament box
@@ -87,6 +126,7 @@ SUBSYSTEM_DEF(auto_equip)
 	..()
 
 	new /obj/item/clothing/accessory/medal/bronze_heart/donator(src)
+	new /obj/item/clothing/glasses/hud/health(src)
 
 /obj/item/clothing/accessory/medal/bronze_heart/donator
 	name = "Donator medal"

--- a/modular_event/tournament/controller.dm
+++ b/modular_event/tournament/controller.dm
@@ -212,7 +212,14 @@ GLOBAL_LIST_EMPTY(tournament_controllers)
 			client?.prefs?.apply_prefs_to(contestant_mob)
 			if(!(contestant_mob.dna?.species?.type in list(/datum/species/human, /datum/species/moth, /datum/species/lizard, /datum/species/human/felinid)))
 				contestant_mob.set_species(/datum/species/human)
-			contestant_mob.equipOutfit(team.outfit)
+			contestant_mob.equipInertOutfit(team.outfit, team.camo_placeholder, changeable = FALSE)
+			var/obj/item/card/id/advanced/centcom/ert/id_card = new(contestant_mob)
+			id_card.desc = "A Toolbox Competitor ID Card"
+			id_card.registered_name = contestant_mob.real_name
+			id_card.assignment = team.name
+			id_card.update_label()
+			id_card.update_icon()
+			contestant_mob.equip_to_slot_if_possible(id_card, ITEM_SLOT_ID, qdel_on_fail = TRUE)
 			contestant_mob.forceMove(pick(valid_team_spawns[team_spawn_id]))
 			contestant_mob.key = client?.key
 			contestant_mob.reset_perspective()

--- a/modular_event/tournament/teams.dm
+++ b/modular_event/tournament/teams.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_INIT_TYPED(tournament_teams, /datum/tournament_team, get_tournament_
 	var/toolbox_color
 	var/list/roster = list()
 	var/datum/outfit/outfit
+	var/datum/outfit/camo_placeholder
 
 /datum/tournament_team/proc/get_clients()
 	var/list/clients = list()
@@ -48,19 +49,40 @@ GLOBAL_LIST_INIT_TYPED(tournament_teams, /datum/tournament_team, get_tournament_
 	if (!islist(outfit_data))
 		return "No outfit provided."
 
-	// MOTHBLOCKS TODO: Make sure none of this has any armor
 	var/datum/outfit/outfit = new
+	var/datum/outfit/camo_placeholder = new
 	outfit.belt = text2path(outfit_data["belt"])
+	if (outfit.belt)
+		camo_placeholder.belt = /obj/item/storage/belt/chameleon
 	outfit.ears = text2path(outfit_data["ears"])
+	if (outfit.ears)
+		camo_placeholder.ears = /obj/item/radio/headset/chameleon
 	outfit.glasses = text2path(outfit_data["glasses"])
+	if (outfit.glasses)
+		camo_placeholder.glasses = /obj/item/clothing/glasses/chameleon
 	outfit.gloves = text2path(outfit_data["gloves"])
+	if (outfit.gloves)
+		camo_placeholder.gloves = /obj/item/clothing/gloves/chameleon
 	outfit.head = text2path(outfit_data["head"])
+	if (outfit.head)
+		camo_placeholder.head = /obj/item/clothing/head/chameleon
 	outfit.mask = text2path(outfit_data["mask"])
+	if (outfit.mask)
+		camo_placeholder.mask = /obj/item/clothing/mask/chameleon
 	outfit.neck = text2path(outfit_data["neck"])
+	if (outfit.neck)
+		camo_placeholder.neck = /obj/item/clothing/neck/chameleon
 	outfit.shoes = text2path(outfit_data["shoes"])
+	if (outfit.shoes)
+		camo_placeholder.shoes = /obj/item/clothing/shoes/chameleon
 	outfit.suit = text2path(outfit_data["suit"])
+	if (outfit.suit)
+		camo_placeholder.suit = /obj/item/clothing/suit/chameleon
 	outfit.uniform = text2path(outfit_data["uniform"])
+	if (outfit.uniform)
+		camo_placeholder.uniform = /obj/item/clothing/under/chameleon
 
+	tournament_team.camo_placeholder = camo_placeholder
 	tournament_team.outfit = outfit
 
 	return tournament_team


### PR DESCRIPTION
<!-- Describe The Pull Request. Please be sure changes are documented for posterity as they may want to refer back to reuse and port all or part of it for future events, also good PR descriptions will make merge delays far less likely. -->
<!-- If this is a Sprite or Map contribution please include screenshots if the diff bots fail for whatever reason. -->

- Populates a placeholder outfit with just the occupied slots chameleon gear
- Equips team members with the placeholder outfit and calls appearance update procs, and removes the action if an arena mob
- Spawns and attempts to equip arena mobs with a team ID
- Also fixed VIP outfit id trim so the assignment does not show as `()`

one snag I will not be addressing for the event is the clash of masks and glasses as some teams selected both so they can just discard one after spawn